### PR TITLE
added address line 2 with proper parameters

### DIFF
--- a/partials/partial-checkout-address.htm
+++ b/partials/partial-checkout-address.htm
@@ -53,8 +53,14 @@
 				<span class="error"></span>
 			</div>
 			<div class="billing-address">
-				<label for="billing_address">Address *</label>
+				<label for="billing_address">Address line 1 *</label>
 				<textarea id="billing_address" name="billingInfo[streetAddressLine1]">{{ billingInfo.streetAddressLine1 }}</textarea>
+				<span class="error"></span>
+			</div>
+
+			<div class="billing-address">
+				<label for="billing_address">Address line 2 (optional)</label>
+				<textarea id="billing_address" name="billingInfo[streetAddressLine2]">{{ billingInfo.streetAddressLine2 }}</textarea>
 				<span class="error"></span>
 			</div>
 

--- a/partials/partial-checkout-address.htm
+++ b/partials/partial-checkout-address.htm
@@ -128,10 +128,17 @@
 					
 				</div>
 				<div class="shipping-address">
-					<label for="shipping_address">Address *</label>
+					<label for="shipping_address">Address line 1*</label>
 					<textarea name="shippingInfo[streetAddressLine1]" id="shipping_address">{{ shippingInfo.streetAddressLine1 }}</textarea>
 					<span class="error"></span>
 				</div>
+
+				<div class="shipping-address">
+					<label for="shipping_address">Address line 2 (optional) *</label>
+					<textarea name="shippingInfo[streetAddressLine2]" id="shipping_address">{{ shippingInfo.streetAddressLine2 }}</textarea>
+					<span class="error"></span>
+				</div>
+
 				<div class="shipping-city">
 					<label for="shipping_city">City *</label>
 					<input type="text" name="shippingInfo[city]" id="shipping_city" value="{{ shippingInfo.city }}"/>

--- a/partials/partial-customerprofile.htm
+++ b/partials/partial-customerprofile.htm
@@ -26,8 +26,14 @@
     </div>
 
     <div class="billing-address">
-      <label for="billing_address">Address</label>
+      <label for="billing_address">Address Line 1</label>
       <textarea id="billing_address" name="billing[street_address]">{{ billing.street_address }}</textarea>
+      <span class="error"></span>
+    </div>
+
+    <div class="billing-address">
+      <label for="billing_address">Address Line 2</label>
+      <textarea id="billing_address" name="billing[street_address_line2]">{{ billing.street_address_line2 }}</textarea>
       <span class="error"></span>
     </div>
 
@@ -103,8 +109,14 @@
       </div>
 
       <div class="shipping-address">
-        <label for="shipping_address">Address</label>
+        <label for="shipping_address">Address Line 1</label>
         <textarea name="shipping[street_address]" id="shipping_address">{{ shipping.street_address }}</textarea>
+        <span class="error"></span>
+      </div>
+
+      <div class="shipping-address">
+        <label for="shipping_address">Address Line 2</label>
+        <textarea name="shipping[street_address_line2]" id="shipping_address">{{ shipping.street_address_line2 }}</textarea>
         <span class="error"></span>
       </div>
 


### PR DESCRIPTION
### Testing Checklist

https://github.com/lemonstand/lemonstand-2/issues/3091
- [x] address line 2 shows up in database after placing order as a guest (shop_customer_address table, street_address_line2 column)
- [x] address line 2 shows in Orders in store backend
- [x] address line 2 shows up for billing and shipping info in front end
- [x] address line 2 field repopulates for logged in users and guest users (same session)
- [x] address line 2 shows up in database when a new customer registers and their address line 2 is added from the `/profile` page
